### PR TITLE
rpi 64 bit profile: add hardware.version=20 as default

### DIFF
--- a/profiles/linux-armv8-rpi-pi4
+++ b/profiles/linux-armv8-rpi-pi4
@@ -10,6 +10,7 @@ gstreamer=1.18
 python=3.8
 rust=1.49
 hardware=rpi
+hardware.version=20
 hardware.board=pi4
 deployment=False
 [options]

--- a/settings.yml
+++ b/settings.yml
@@ -19,7 +19,7 @@ hardware:
   rpi:
     # Raspberry devices
       # Raspbian os version, if installed 
-      version:     ["10"]
+      version:     ["10", "20"]
       # RPi4: pi4
       board:       ["pi4"]
   generic: ~


### PR DESCRIPTION
# PR Checklist

1. Added "20" option for rpi hardware.version
2. Added "20" as default hardware.version to linux-armv8-rpi-pi4